### PR TITLE
ensure unicode transmitted proprely

### DIFF
--- a/lib/XML/TreePP.pm
+++ b/lib/XML/TreePP.pm
@@ -646,7 +646,7 @@ sub parsehttp_lwp {
     if ( defined $body && ! $ct ) {
         $req->header( 'Content-Type' => 'application/x-www-form-urlencoded' );
     }
-    $req->content($body) if defined $body;
+    $req->add_content_utf8($body) if defined $body;
     my $res = $ua->request($req);
     my $code = $res->code();
     my $text;


### PR DESCRIPTION
This pull request is to alert the author of a problem.

```
   my $ua
    = load_class('LWP::UserAgent')->new(
        ssl_opts => { verify_hostname => 0 },
    );

$xmlrpc->{tpp}->set( lwp_useragent   => $ua     );
$xmlrpc->{tpp}->set( output_encoding => 'UTF-8' );
$xmlrpc->{tpp}->set( utf8_flag => 1 );
```

All of the above was set and the problem still occurred.

The below hack, is most certainly wrong, but it seems to force the desired behavior. seems like Content-Length may be getting set wrong somewhere, after making this change LWP warns that it's correcting `Content-Length` on the calls that were having problems with transmitting unicode.

I could probably get sample data if it would help fix the problem
