### PR TITLE
Sync OpenBSD patches from their Ports tree

### DIFF
--- a/lib/XML/TreePP.pm
+++ b/lib/XML/TreePP.pm
@@ -635,7 +635,6 @@ sub parsehttp_lwp {
     my $ua = $self->{lwp_useragent} if exists $self->{lwp_useragent};
     if ( ! ref $ua ) {
         $ua = LWP::UserAgent->new();
-        $ua->timeout(10);
         $ua->env_proxy();
         $ua->agent( $self->{__user_agent} ) if defined $self->{__user_agent};
     } else {

--- a/t/09_http-lite.t
+++ b/t/09_http-lite.t
@@ -21,10 +21,10 @@ sub parsehttp_get {
     my $tpp = XML::TreePP->new();
     my $name = ( $0 =~ m#([^/:\\]+)$# )[0];
     $tpp->set( user_agent => "$name " );
-    my $url = "http://use.perl.org/index.rss";
+    my $url = "http://rss.slashdot.org/Slashdot/slashdot";
     my $tree = $tpp->parsehttp( GET => $url );
     ok( ref $tree, $url );
-    like( $tree->{"rdf:RDF"}->{channel}->{link}, qr{^http://}, "$url link" );
+    like( $tree->{"rss"}->{channel}->{link}, qr{^http://}, "$url link" );
 }
 # ----------------------------------------------------------------
 sub parsehttp_post {

--- a/t/10_http-lwp.t
+++ b/t/10_http-lwp.t
@@ -21,10 +21,10 @@ sub parsehttp_get {
     my $tpp = XML::TreePP->new();
     my $name = ( $0 =~ m#([^/:\\]+)$# )[0];
     $tpp->set( user_agent => "$name " );
-    my $url = "http://use.perl.org/index.rss";
+    my $url = "http://rss.slashdot.org/Slashdot/slashdot";
     my $tree = $tpp->parsehttp( GET => $url );
     ok( ref $tree, $url );
-    like( $tree->{"rdf:RDF"}->{channel}->{link}, qr{^http://}, "$url link" );
+    like( $tree->{"rss"}->{channel}->{link}, qr{^http://}, "$url link" );
 }
 # ----------------------------------------------------------------
 sub parsehttp_post {


### PR DESCRIPTION
- timeout of 10 seconds is way too low, stick with defaults
- use.perl.org returns http 500, use different rss feed

Those changes make regress on OpenBSD happy. I've removed timeout of
10 seconds as while using the module it was timing out way to often.
I think timeout should be bumped up, or as I prefer it, just keep it
as default and remove it completely.
